### PR TITLE
update(init): 初回実行時に最大過去30日分のデータを取得

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -9,7 +9,6 @@
 */
 
 var CACHE_KEY          = 'toggl_exporter:lastmodify_datetime';
-var TIME_OFFSET        = 9 * 60 * 60; // JST
 var TOGGL_BASIC_AUTH   = 'REPLACE_ME:api_token';
 var GOOGLE_CALENDAR_ID = 'REPLACE_ME';
 
@@ -17,8 +16,7 @@ function getLastModifyDatetime() {
   var cache = {};
   var file = DriveApp.getFilesByName('toggl_exporter_cache');
   if(!file.hasNext()) {
-    var now = Moment.moment().format('X');
-    var beginning_of_day = parseInt(now - (now % 86400 * 7 + TIME_OFFSET), 10).toFixed();
+    var beginning_of_day = parseInt(Moment.moment().subtract(30, "days").format("X"), 10).toFixed();
     putLastModifyDatetime(beginning_of_day);
     return beginning_of_day;
   }
@@ -41,7 +39,7 @@ function putLastModifyDatetime(unix_timestamp) {
 }
 
 function getTimeEntries(unix_timestamp) {
-  var uri = 'https://www.toggl.com/api/v8/time_entries' + '?' + 'start_date=' + encodeURIComponent(Moment.moment(unix_timestamp, 'X').format());
+  var uri = 'https://api.track.toggl.com/api/v8/time_entries' + '?' + 'start_date=' + encodeURIComponent(Moment.moment(unix_timestamp, 'X').format());
   var response = UrlFetchApp.fetch(
     uri,
     {
@@ -103,6 +101,7 @@ function watch() {
           Moment.moment(record.start).format(),
           Moment.moment(record.stop).format()
         );
+        Utilities.sleep(2 * 1000);
         last_stop_datetime = record.stop;
       }
       if(last_stop_datetime) {

--- a/main.gs
+++ b/main.gs
@@ -18,7 +18,7 @@ function getLastModifyDatetime() {
   var file = DriveApp.getFilesByName('toggl_exporter_cache');
   if(!file.hasNext()) {
     var now = Moment.moment().format('X');
-    var beginning_of_day = parseInt(now - (now % 86400 + TIME_OFFSET), 10).toFixed();
+    var beginning_of_day = parseInt(now - (now % 86400 * 7 + TIME_OFFSET), 10).toFixed();
     putLastModifyDatetime(beginning_of_day);
     return beginning_of_day;
   }


### PR DESCRIPTION
素晴らしいスクリプトを作成していただき大変ありがどうございます。
初回実行時に、もしTogglに記録データがあればそれも含めてカレンダーに転記します。

API経由で1000件まで取れそう
https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-time-entries-started-in-a-specific-time-range

詳細は c5fc291 のコミットログまで。